### PR TITLE
Square switch with color bug

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -241,6 +241,50 @@
 								</span>
 							</label>
 						</div>
+						<div class="col-12">
+							<label class="toggle-switchy" for="example_21" data-size="sm" data-color="red">
+								<input checked type="checkbox" id="example_21">
+								<span class="toggle">
+									<span class="switch"></span>
+								</span>
+							</label>
+							<label class="toggle-switchy" for="example_22" data-size="sm" data-color="orange">
+								<input checked type="checkbox" id="example_22">
+								<span class="toggle">
+									<span class="switch"></span>
+								</span>
+							</label>
+							<label class="toggle-switchy" for="example_23" data-size="sm" data-color="yellow">
+								<input checked type="checkbox" id="example_23">
+								<span class="toggle">
+									<span class="switch"></span>
+								</span>
+							</label>
+							<label class="toggle-switchy" for="example_24" data-size="sm" data-color="green">
+								<input checked type="checkbox" id="example_24">
+								<span class="toggle">
+									<span class="switch"></span>
+								</span>
+							</label>
+							<label class="toggle-switchy" for="example_25" data-size="sm" data-color="blue">
+								<input checked type="checkbox" id="example_25">
+								<span class="toggle">
+									<span class="switch"></span>
+								</span>
+							</label>
+							<label class="toggle-switchy" for="example_26" data-size="sm" data-color="purple">
+								<input checked type="checkbox" id="example_26">
+								<span class="toggle">
+									<span class="switch"></span>
+								</span>
+							</label>
+							<label class="toggle-switchy" for="example_27" data-size="sm" data-color="gray">
+								<input checked type="checkbox" id="example_27">
+								<span class="toggle">
+									<span class="switch"></span>
+								</span>
+							</label>
+						</div>
 					</div>
 
 					<div class="row mb-4">

--- a/toggle-switchy.css
+++ b/toggle-switchy.css
@@ -109,28 +109,35 @@ CORE STYLES ABOVE - NO TOUCHY
 
 /* Color: Red */
 .toggle-switchy[data-color='red'] > input:checked + .toggle {background:#e74c3c;}
+.toggle-switchy[data-color='red'] > input:checked + .toggle > .switch,
 .toggle-switchy[data-color='red'][data-style='rounded'] > input:checked + .toggle > .switch {border-color:#e74c3c;}
 
 /* Color: Orange */
 .toggle-switchy[data-color='orange'] > input:checked + .toggle {background:#e67e22;}
+.toggle-switchy[data-color='orange'] > input:checked + .toggle > .switch,
 .toggle-switchy[data-color='orange'][data-style='rounded'] > input:checked + .toggle > .switch {border-color:#e67e22;}
  
  /* Color: Yellow */
 .toggle-switchy[data-color='yellow'] > input:checked + .toggle {background:#f1c40f;}
+.toggle-switchy[data-color='yellow'] > input:checked + .toggle > .switch,
 .toggle-switchy[data-color='yellow'][data-style='rounded'] > input:checked + .toggle > .switch {border-color:#f1c40f;}
 
 /* Color: Green */
 .toggle-switchy[data-color='green'] > input:checked + .toggle {background:#2ecc71;}
+.toggle-switchy[data-color='green'] > input:checked + .toggle > .switch,
 .toggle-switchy[data-color='green'][data-style='rounded'] > input:checked + .toggle > .switch {border-color:#2ecc71;}
 
 /* Color: Blue */
 .toggle-switchy[data-color='blue'] > input:checked + .toggle {background:#3498db;}
+.toggle-switchy[data-color='blue'] > input:checked + .toggle > .switch,
 .toggle-switchy[data-color='blue'][data-style='rounded'] > input:checked + .toggle > .switch {border-color:#3498db;}
 
 /* Color: Purple */
 .toggle-switchy[data-color='purple'] > input:checked + .toggle {background:#9b59b6;}
+.toggle-switchy[data-color='purple'] > input:checked + .toggle > .switch,
 .toggle-switchy[data-color='purple'][data-style='rounded'] > input:checked + .toggle > .switch {border-color:#9b59b6;}
 
 /* Color: Gray */
 .toggle-switchy[data-color='gray'] > input:checked + .toggle {background:#555;}
+.toggle-switchy[data-color='gray'] > input:checked + .toggle > .switch,
 .toggle-switchy[data-color='gray'][data-style='rounded'] > input:checked + .toggle > .switch {border-color:#555;}


### PR DESCRIPTION
Fixing bug when using the non-rounded switch with a color, the border of the switch was not the correct color.

Also updated the docs to add a square version of the switch below the rounded version.